### PR TITLE
Fix for EnumAdapterMode issues

### DIFF
--- a/src/Common/Logging.h
+++ b/src/Common/Logging.h
@@ -82,6 +82,10 @@ extern thread_local std::string _logPrefix;
 	#define LOG_FUNC_ARG(arg) \
 			msg << "\n   " << std::setw(26) << std::left << std::setfill(' ') << #arg" : " << arg;
 
+	// LOG_FUNC_ARG_STR writes a pointer-based string argument, rendering nulls as <nullptr>
+	#define LOG_FUNC_ARG_STR(arg) \
+			msg << "\n   " << std::setw(26) << std::left << std::setfill(' ') << #arg" : " << (arg == NULL ? "<nullptr>" : arg);
+
 	// LOG_FUNC_ARG_OUT prevents expansion of types, by only rendering as a pointer
 	#define LOG_FUNC_ARG_OUT(arg) \
 			msg << "\n   " << std::setw(26) << std::left << std::setfill(' ') << #arg << " : 0x" << (void*)arg;
@@ -99,6 +103,7 @@ extern thread_local std::string _logPrefix;
 #else
 	#define LOG_FUNC_BEGIN 
 	#define LOG_FUNC_ARG(arg)
+	#define LOG_FUNC_ARG_STR(arg)
 	#define LOG_FUNC_ARG_OUT(arg)
 	#define LOG_FUNC_END
 	#define LOG_FUNC_RESULT(r)

--- a/src/CxbxKrnl/EmuFile.cpp
+++ b/src/CxbxKrnl/EmuFile.cpp
@@ -267,7 +267,7 @@ NTSTATUS CxbxObjectAttributesToNT(xboxkrnl::POBJECT_ATTRIBUTES ObjectAttributes,
 		DbgPrintf("  Org:\"%s\"\n", OriginalPath.c_str());
 		if (_strnicmp(NativePath.c_str(), CxbxBasePath.c_str(), CxbxBasePath.length()) == 0)
 		{
-			DbgPrintf("  New:\"$CxbxPath\\EmuDisk\\%s%s\"\n", (NativePath.substr(CxbxBasePath.length(), std::string::npos)).c_str(), RelativePath.c_str());
+			DbgPrintf("  New:\"$CxbxPath\\EmuDisk\\%s\\%s\"\n", (NativePath.substr(CxbxBasePath.length(), std::string::npos)).c_str(), RelativePath.c_str());
 		}
 		else
 			DbgPrintf("  New:\"$XbePath\\%s\"\n", RelativePath.c_str());

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -815,7 +815,7 @@ DWORD WINAPI XTL::EmuXLaunchNewImage
 )
 {
 	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(lpTitlePath)
+		LOG_FUNC_ARG_STR(lpTitlePath)
 		LOG_FUNC_ARG(pLaunchData)
 		LOG_FUNC_END;
 


### PR DESCRIPTION
The rationale here is that these functions should return the same video modes that would exist on an Xbox instead of whatever the host machine happens to return. The list is probably incomplete, but works for now and makes Panzer Dragoon Orta and JSRF boot up properly. This fixes issue #22.

There are a couple of minor logging fixes included here too.