### PR TITLE
Overlay cleanup

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -115,7 +115,7 @@ static BOOL                         g_bHasDepthStencil = FALSE;  // Does device 
 static DWORD						g_dwPrimPerFrame = 0;	// Number of primitives within one frame
 
 struct {
-	XTL::X_D3DSurface *pSurface;
+	XTL::X_D3DSurface Surface;
 	RECT SrcRect;
 	RECT DstRect;
 	BOOL EnableColorKey;
@@ -168,7 +168,7 @@ static UINT                         QuadToTriangleIndexBuffer_Size = 0; // = NrO
 static XTL::X_D3DSurface		   *g_XboxBackBufferSurface = NULL;
 static XTL::X_D3DSurface           *g_pXboxRenderTarget = NULL;
 static XTL::X_D3DSurface           *g_pXboxDepthStencil = NULL;
-static BOOL                         g_fYuvEnabled = FALSE;
+static bool                         g_bColorSpaceConvertYuvToRgb = false;
 static DWORD                        g_dwVertexShaderUsage = 0;
 static DWORD                        g_VertexShaderSlots[136];
 
@@ -4601,13 +4601,23 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 			}
 		}
 
-		if (g_OverlayProxy.pSurface && g_fYuvEnabled) {
+		// Is there an overlay to be presented too?
+		if (g_OverlayProxy.Surface.Common) {
+
+			X_D3DFORMAT X_Format = GetXboxPixelContainerFormat(&g_OverlayProxy.Surface);
+			if (X_Format != X_D3DFMT_YUY2) {
+				LOG_TEST_CASE("Xbox overlay surface isn't using X_D3DFMT_YUY2");
+			}
+
+			// Interpret the Xbox overlay data (depending the color space conversion render state)
+			// as either YUV or RGB format (note that either one must be a 3 bytes per pixel format)
+			D3DFORMAT PCFormat = g_bColorSpaceConvertYuvToRgb ? D3DFMT_R8G8B8 : D3DFMT_YUY2;
 
 			// Blit Xbox overlay to host backbuffer
-			uint08 *pOverlayData = (uint08*)GetDataFromXboxResource(g_OverlayProxy.pSurface);
+			uint08 *pOverlayData = (uint08*)GetDataFromXboxResource(&g_OverlayProxy.Surface);
 			UINT OverlayWidth, OverlayHeight, OverlayDepth, OverlayRowPitch, OverlaySlicePitch;
 			CxbxGetPixelContainerMeasures(
-				(XTL::X_D3DPixelContainer *)g_OverlayProxy.pSurface,
+				&g_OverlayProxy.Surface,
 				0, // dwMipMapLevel
 				&OverlayWidth, &OverlayHeight, &OverlayDepth, &OverlayRowPitch, &OverlaySlicePitch);
 
@@ -4634,7 +4644,7 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 			// Get backbuffer dimenions; TODO : remember this once, at creation/resize time
 			D3DSURFACE_DESC BackBufferDesc;
 			pCurrentHostBackBuffer->GetDesc(&BackBufferDesc);
-#if 0
+
 			// Limit the width and height of the output to the backbuffer dimensions.
 			// This will (hopefully) prevent exceptions in Blinx - The Time Sweeper
 			// (see https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/285)
@@ -4642,26 +4652,24 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 				// Use our (bounded) copy when bounds exceed :
 				if (EmuDestRect.right > (LONG)BackBufferDesc.Width) {
 					EmuDestRect.right = (LONG)BackBufferDesc.Width;
-					DstRect = &EmuDestRect;
 				}
 
 				if (EmuDestRect.bottom > (LONG)BackBufferDesc.Height) {
 					EmuDestRect.bottom = (LONG)BackBufferDesc.Height;
-					DstRect = &EmuDestRect;
 				}
 			}
-#endif
+
 			// Use D3DXLoadSurfaceFromMemory() to do conversion, stretching and filtering
 			// avoiding the need for YUY2toARGB() (might become relevant when porting to D3D9 or OpenGL)
 			// see https://msdn.microsoft.com/en-us/library/windows/desktop/bb172902(v=vs.85).aspx
 			hRet = D3DXLoadSurfaceFromMemory(
 				/* pDestSurface = */ pCurrentHostBackBuffer,
-				/* pDestPalette = */ nullptr, // Palette not needed for YUY2
+				/* pDestPalette = */ nullptr,
 				/* pDestRect = */ &EmuDestRect,
 				/* pSrcMemory = */ pOverlayData, // Source buffer
-				/* SrcFormat = */ D3DFMT_YUY2,
+				/* SrcFormat = */ PCFormat,
 				/* SrcPitch = */ OverlayRowPitch,
-				/* pSrcPalette = */ nullptr, // Palette not needed for YUY2
+				/* pSrcPalette = */ nullptr,
 				/* SrcRect = */ &EmuSourRect,
 				/* Filter = */ D3DX_FILTER_POINT, // Dxbx note : D3DX_FILTER_LINEAR gives a smoother image, but 'bleeds' across borders
 				/* ColorKey = */ g_OverlayProxy.EnableColorKey ? g_OverlayProxy.ColorKey : 0);
@@ -5563,9 +5571,12 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_EnableOverlay)
 	FUNC_EXPORTS
 
 	LOG_FUNC_ONE_ARG(Enable);
-	g_fYuvEnabled = Enable;
-
-	// We can safely ignore this, as long as we properly handle UpdateOverlay
+	
+	// The Xbox D3DDevice_EnableOverlay call merely resets the active
+	// NV2A overlay state, it doesn't actually enable or disable anything.
+	// Thus, we should just reset our overlay state here too. A title will
+	// show new overlay data via D3DDevice_UpdateOverlay (see below).
+	g_OverlayProxy = {};
 }
 
 // ******************************************************************
@@ -5578,11 +5589,11 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_UpdateOverlay)
 	CONST RECT   *DstRect,
 	BOOL          EnableColorKey,
 	D3DCOLOR      ColorKey
-	)
+)
 {
 	FUNC_EXPORTS
 
-		LOG_FUNC_BEGIN
+	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pSurface)
 		LOG_FUNC_ARG(SrcRect)
 		LOG_FUNC_ARG(DstRect)
@@ -5590,22 +5601,27 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_UpdateOverlay)
 		LOG_FUNC_ARG(ColorKey)
 		LOG_FUNC_END;
 
+	// Reset and remember the overlay arguments, so our D3DDevice_Swap patch
+	// can correctly show this overlay surface data.
 	g_OverlayProxy = {};
-	g_OverlayProxy.pSurface = pSurface;
-	if (SrcRect)
-		g_OverlayProxy.SrcRect = *SrcRect;
-	if (DstRect)
-		g_OverlayProxy.DstRect = *DstRect;
-	g_OverlayProxy.EnableColorKey = EnableColorKey;
-	g_OverlayProxy.ColorKey = ColorKey;
+	if (pSurface) {
+		g_OverlayProxy.Surface = *pSurface;
+		if (SrcRect)
+			g_OverlayProxy.SrcRect = *SrcRect;
 
-	// Update overlay if present was not called since the last call to
-	// EmuD3DDevice_UpdateOverlay.
-	if (g_OverlaySwap != g_SwapData.Swap - 1) {
-		EMUPATCH(D3DDevice_Swap)(CXBX_SWAP_PRESENT_FORWARD);
+		if (DstRect)
+			g_OverlayProxy.DstRect = *DstRect;
+
+		g_OverlayProxy.EnableColorKey = EnableColorKey;
+		g_OverlayProxy.ColorKey = ColorKey;
+		// Update overlay if present was not called since the last call to
+		// EmuD3DDevice_UpdateOverlay.
+		if (g_OverlaySwap != g_SwapData.Swap - 1) {
+			EMUPATCH(D3DDevice_Swap)(CXBX_SWAP_PRESENT_FORWARD);
+		}
+
+		g_OverlaySwap = g_SwapData.Swap;
 	}
-
-	g_OverlaySwap = g_SwapData.Swap;
 }
 
 // ******************************************************************
@@ -6633,15 +6649,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_YuvEnable)
 
 	LOG_FUNC_ONE_ARG(Enable);
 
-    // HACK: Display YUV surface by using an overlay.
-    if(Enable != g_fYuvEnabled)
-    {
-        g_fYuvEnabled = Enable;
-
-        EmuWarning("EmuD3DDevice_SetRenderState_YuvEnable using overlay!");
-        
-		EMUPATCH(D3DDevice_EnableOverlay)(g_fYuvEnabled);
-    }
+    g_bColorSpaceConvertYuvToRgb = (Enable != FALSE);
 }
 
 // LTCG specific D3DDevice_SetTransform function...

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -922,12 +922,12 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x2A X_D3DFMT_D24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
 #ifdef CXBX_USE_D3D9
 	/* 0x2B X_D3DFMT_F24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24FS8    , DepthBuffer },
-	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
+	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer }, // Note : X_D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not, but D3DFMT_D16_LOCKABLE often fails SetRenderTarget.
+	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
 	/* 0x2E X_D3DFMT_LIN_D24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
 	/* 0x2F X_D3DFMT_LIN_F24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24FS8    , DepthBuffer },
-	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
+	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer }, // Note : X_D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not, but D3DFMT_D16_LOCKABLE often fails SetRenderTarget.
+	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
 	/* 0x32 X_D3DFMT_L16          */ { 16, Swzzld, _____L16, XTL::D3DFMT_L16       },
 	/* 0x33 X_D3DFMT_V16U16       */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_V16U16    },
 	/* 0x34 undefined             */ {},
@@ -944,12 +944,12 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x3F X_D3DFMT_LIN_A8B8G8R8 */ { 32, Linear, A8B8G8R8, XTL::D3DFMT_A8B8G8R8  }, // Note : D3DFMT_A8B8G8R8=32 D3DFMT_Q8W8V8U8=63 // TODO : Needs testcase.
 #else // Direct3D8 :
 	/* 0x2B X_D3DFMT_F24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer, "X_D3DFMT_F24S8 -> D3DFMT_D24S8" }, // HACK : PC doesn't have D3DFMT_F24S8 (Float vs Int)
-	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
+	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer }, // Note : X_D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not, but D3DFMT_D16_LOCKABLE often fails SetRenderTarget.
+	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
 	/* 0x2E X_D3DFMT_LIN_D24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
 	/* 0x2F X_D3DFMT_LIN_F24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer, "X_D3DFMT_LIN_F24S8 -> D3DFMT_D24S8" }, // HACK : PC doesn't have D3DFMT_F24S8 (Float vs Int)
-	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
+	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer }, // Note : X_D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not, but D3DFMT_D16_LOCKABLE often fails SetRenderTarget.
+	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
 	/* 0x32 X_D3DFMT_L16          */ { 16, Swzzld, _____L16, XTL::D3DFMT_A8L8      , Texture, "X_D3DFMT_L16 -> D3DFMT_A8L8" },
 	/* 0x33 X_D3DFMT_V16U16       */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_V16U16    },
 	/* 0x34 undefined             */ {},
@@ -1079,7 +1079,7 @@ XTL::D3DFORMAT XTL::EmuXB2PC_D3DFormat(X_D3DFORMAT Format)
 	return D3DFMT_UNKNOWN;
 }
 
-XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format)
+XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format, bool bPreferLinear = true)
 {
 	X_D3DFORMAT result;
     switch(Format)
@@ -1091,91 +1091,69 @@ XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format)
 		result = X_D3DFMT_UYVY;
 		break;
 	case D3DFMT_R5G6B5:
-		result = X_D3DFMT_LIN_R5G6B5;
-		break; // Linear
-			   //      Result := X_D3DFMT_R5G6B5; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_R5G6B5 : X_D3DFMT_R5G6B5;
+		break;
 	case D3DFMT_D24S8:
-		result = X_D3DFMT_D24S8;
-		break; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_D24S8 : X_D3DFMT_D24S8;
+		break;
 	case D3DFMT_DXT5:
-		result = X_D3DFMT_DXT5;
-		break; // Compressed
-
+		result = X_D3DFMT_DXT5; // Compressed
+		break;
 	case D3DFMT_DXT4:
-		result = X_D3DFMT_DXT4; // Same as X_D3DFMT_DXT5
-		break; // Compressed
-
+		result = X_D3DFMT_DXT4;  // Compressed // Same as X_D3DFMT_DXT5
+		break;
 	case D3DFMT_DXT3:
-		result = X_D3DFMT_DXT3;
-		break; // Compressed
-
+		result = X_D3DFMT_DXT3; // Compressed
+		break;
 	case D3DFMT_DXT2:
-		result = X_D3DFMT_DXT2; // Same as X_D3DFMT_DXT3
-		break; // Compressed
-
+		result = X_D3DFMT_DXT2; // Compressed // Same as X_D3DFMT_DXT3
+		break;
 	case D3DFMT_DXT1:
-		result = X_D3DFMT_DXT1;
-		break; // Compressed
-
+		result = X_D3DFMT_DXT1; // Compressed
+		break;
 	case D3DFMT_A1R5G5B5:
-		result = X_D3DFMT_LIN_A1R5G5B5;
-		break; // Linear
-
+		result = bPreferLinear ? X_D3DFMT_LIN_A1R5G5B5 : X_D3DFMT_A1R5G5B5;
+		break;
 	case D3DFMT_X8R8G8B8:
-		result = X_D3DFMT_LIN_X8R8G8B8;
-		break; // Linear
-			   //      Result := X_D3DFMT_X8R8G8B8; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_X8R8G8B8 : X_D3DFMT_X8R8G8B8;
+		break;
 	case D3DFMT_A8R8G8B8:
-		//      Result := X_D3DFMT_LIN_A8R8G8B8; // Linear
-		result = X_D3DFMT_A8R8G8B8;
+		result = bPreferLinear ? X_D3DFMT_LIN_A8R8G8B8 : X_D3DFMT_A8R8G8B8;
 		break;
 	case D3DFMT_A4R4G4B4:
-		result = X_D3DFMT_LIN_A4R4G4B4;
-		break; // Linear
-			   //      Result := X_D3DFMT_A4R4G4B4; // Swizzled
-	case D3DFMT_X1R5G5B5:	// Linear
-		result = X_D3DFMT_LIN_X1R5G5B5;
+		result = bPreferLinear ? X_D3DFMT_LIN_A4R4G4B4 : X_D3DFMT_A4R4G4B4;
+		break;
+	case D3DFMT_X1R5G5B5:
+		result = bPreferLinear ? X_D3DFMT_LIN_X1R5G5B5 : X_D3DFMT_X1R5G5B5;
 		break;
 	case D3DFMT_A8:
-		result = X_D3DFMT_A8;
+		result = bPreferLinear ? X_D3DFMT_LIN_A8 : X_D3DFMT_A8;
 		break;
 	case D3DFMT_L8:
-		result = X_D3DFMT_LIN_L8;
-		break; // Linear
-			   //        Result := X_D3DFMT_L8; // Swizzled
-
-	case D3DFMT_D16: // Swizzled
-		return X_D3DFMT_D16;
+		result = bPreferLinear ? X_D3DFMT_LIN_L8 : X_D3DFMT_L8;
 		break;
-	case D3DFMT_D16_LOCKABLE: // Swizzled
+	case D3DFMT_D16:
+		result = bPreferLinear ? X_D3DFMT_LIN_D16 : X_D3DFMT_D16;
+		break;
+	case D3DFMT_D16_LOCKABLE:
 		result = X_D3DFMT_D16_LOCKABLE;
 		break; 
-
 	case D3DFMT_UNKNOWN:
-		result = ((X_D3DFORMAT)0xffffffff);
+		result = ((X_D3DFORMAT)0xffffffff); // TODO : return X_D3DFMT_UNKNOWN ?
 		break;
-
-		// Dxbx additions :
-
+	// Dxbx additions :
 	case D3DFMT_L6V5U5:
-		result = X_D3DFMT_L6V5U5;
-		break; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_L6V5U5 : X_D3DFMT_L6V5U5;
+		break;
 	case D3DFMT_V8U8:
-		result = X_D3DFMT_V8U8;
-		break; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_V8U8 : X_D3DFMT_V8U8;
+		break;
 	case D3DFMT_V16U16:
-		result = X_D3DFMT_V16U16;
-		break; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_V16U16 : X_D3DFMT_V16U16;
+		break;
 	case D3DFMT_VERTEXDATA:
 		result = X_D3DFMT_VERTEXDATA;
 		break;
-
 	default:
 		CxbxKrnlCleanup("EmuPC2XB_D3DFormat: Unknown Format (%d)", Format);
     }

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -77,7 +77,7 @@ extern BOOL EmuXBFormatIsDepthBuffer(X_D3DFORMAT Format);
 extern D3DFORMAT EmuXB2PC_D3DFormat(X_D3DFORMAT Format);
 
 // convert from pc to xbox color formats
-extern X_D3DFORMAT EmuPC2XB_D3DFormat(D3DFORMAT Format);
+extern X_D3DFORMAT EmuPC2XB_D3DFormat(D3DFORMAT Format, bool bPreferLinear = true);
 
 // convert from xbox to pc d3d lock flags
 extern DWORD EmuXB2PC_D3DLock(DWORD Flags);


### PR DESCRIPTION
This PR improves upon my previous overlay fixes, including D3D format conversion from host back to Xbox (only used for icons, but still).

The main benefit of this work is it's less crash-prone (because I now copy the overlay surface into the proxy overlay struct) and it tries to honor the color-space conversion render state (by interpreting overlay data as RGB when the NV2A is asked to do so). This work also restores the limiting of the overlay dimensions to backbuffer dimensions (a fix for BLinx - the time sweeper).