### PR TITLE
Fix system buttons

### DIFF
--- a/src/devices/chihiro/JvsIo.cpp
+++ b/src/devices/chihiro/JvsIo.cpp
@@ -188,7 +188,7 @@ int JvsIo::Jvs_Command_20_ReadSwitchInputs(uint8_t* data)
 
 	ResponseBuffer.push_back(ReportCode::Handled);
 
-	ResponseBuffer.push_back(Inputs.switches.system);
+	ResponseBuffer.push_back(Inputs.switches.system.GetByte0());
 
 	for (int i = 0; i < nr_switch_players; i++) {
 		for (int j = 0; j < bytesPerSwitchPlayerInput; j++) {

--- a/src/devices/chihiro/JvsIo.h
+++ b/src/devices/chihiro/JvsIo.h
@@ -73,7 +73,23 @@ typedef struct {
 } jvs_switch_player_inputs_t;
 
 typedef struct {
-	uint8_t system = false;
+	bool test = false;
+	bool tilt1 = false;
+	bool tilt2 = false;
+	bool tilt3 = false;
+
+	uint8_t GetByte0() {
+		uint8_t value = 0;
+		value |= test      ? 1 << 7 : 0;
+		value |= tilt1     ? 1 << 6 : 0;
+		value |= tilt2     ? 1 << 5 : 0;
+		value |= tilt3     ? 1 << 4 : 0;
+		return value;
+	}
+} jvs_switch_system_inputs_t;
+
+typedef struct {
+	jvs_switch_system_inputs_t system;
 	jvs_switch_player_inputs_t player[JVS_MAX_PLAYERS];
 } jvs_switch_inputs_t;
 


### PR DESCRIPTION
System button handling was broken on hardware, test button was responding as if it was hitting `tilt3`.

Untested if anything else in CXBX-R touches the `uint8_t system` variable.