### PR TITLE
identify 1 byte in boot.id and a filterboard switch

### DIFF
--- a/src/core/hle/JVS/JVS.cpp
+++ b/src/core/hle/JVS/JVS.cpp
@@ -52,7 +52,7 @@ mio::mmap_sink g_BaseBoardBackupMemory;		// Backup Memory (high-scores, etc)
 typedef struct {
 	// Switch 1:	Horizontal Display, On = Vertical Display
 	// Switch 2-3:	D3D Resolution Configuraton
-	// Switch 4:	0 = Hardware Vertex Processing, 1 = Software Vertex processing (Causes D3D to fail).. Why does this exist?
+	// Switch 4:	0 = Hardware Vertex Processing, 1 = Software Vertex processing (Causes D3D to fail).. Horizontal frequency?
 	// Switch 5:	Unknown
 	// Switch 6-8:	Connected AV Pack flag
 	bool DipSwitch[8];

--- a/src/devices/chihiro/MediaBoard.h
+++ b/src/devices/chihiro/MediaBoard.h
@@ -59,7 +59,8 @@ typedef struct {
     uint16_t year;              // 0x28
     uint8_t month;              // 0x2A
     uint8_t day;                // 0x2B
-    uint8_t unknown3[2];
+    uint8_t videoMode;          // 0x2C unknown bitmask, resolutions + horizontal/vertical
+    uint8_t unknown3;
     uint8_t type3Compatible;    // 0x2E (Type-3 compatibile titles have this set to 1)
     uint8_t unknown4;
     char gameId[8];             // 0x30


### PR DESCRIPTION
Identify the video mode byte in `boot.id` and make the assumption based on error codes that dip4 is horizontal freq